### PR TITLE
update support for smaller iphones

### DIFF
--- a/src/components/Bar.tsx
+++ b/src/components/Bar.tsx
@@ -67,7 +67,7 @@ const Wrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 100px 0 50px 0;
+  padding: 50px 0 50px 0;
   position: relative;
 `;
 

--- a/src/components/InputDisplay.tsx
+++ b/src/components/InputDisplay.tsx
@@ -77,13 +77,18 @@ const InputDisplay: React.FC<any> = () => {
         ))}
       </StyledIonSelect>
       <IonButton onClick={() => handleOnClick()}>Calc</IonButton>
-      {Number(inputWeight) !== finalWeight && (
-        <IonText color='warning'>
-          <p>
-            Final Weight: <span>{finalWeight}</span>{' '}
-          </p>
-        </IonText>
-      )}
+      <IonText color='warning'>
+        <p
+          style={{
+            visibility:
+              Number(inputWeight) !== finalWeight && finalWeight !== 0
+                ? 'visible'
+                : 'hidden',
+          }}
+        >
+          Final Weight: <span>{finalWeight}</span>{' '}
+        </p>
+      </IonText>
     </Wrapper>
   );
 };
@@ -110,5 +115,5 @@ const StyledIonSelect = styled(IonSelect)`
 `;
 
 const Input = styled(IonInput)<{ value: string }>`
-  font-size: 110px;
+  font-size: 90px;
 `;


### PR DESCRIPTION
Plate badges are overflowing out of the screen. 
Decrease text of input. Reduce top padding of barbell 
Remove shifting when finalWeight is displayed vs not displayed. 